### PR TITLE
Add PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+.php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "require-dev": {
-        "alexeyshockov/guzzle-psalm-plugin": "^0.2.1",
+        "alexeyshockov/guzzle-psalm-plugin": "^0.3.1",
         "friendsofphp/php-cs-fixer": "^2.16",
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-master",
-        "vimeo/psalm": "^3.11"
+        "vimeo/psalm": "^4.4"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          colors="true"
 >
+    <coverage>
+        <include>
+          <directory>src</directory>
+        </include>
+    </coverage>
+
     <php>
-        <ini name="error_reporting" value="-1" />
+        <ini name="error_reporting" value="-1"/>
     </php>
 
     <testsuites>
@@ -14,10 +19,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -29,7 +29,6 @@
         <MissingReturnType errorLevel="info"/>
         <MissingPropertyType errorLevel="info"/>
         <InvalidDocblock errorLevel="info"/>
-        <MisplacedRequiredParam errorLevel="info"/>
 
         <PropertyNotSetInConstructor errorLevel="info"/>
         <MissingConstructor errorLevel="info"/>


### PR DESCRIPTION
This can be released as a minor version, as there are no BC breaks.